### PR TITLE
chore(specs): revue de spécifications — cohérence docs + injection config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,13 @@
 
 ## Présentation du projet
 
-**OntoWave** est un noyau de navigation (~100KB, **zéro dépendance**) pour sites statiques et applications web. Il transforme des fichiers Markdown en documentation interactive dans le navigateur, avec routing SPA basé sur le hash URL et chargement d'extensions à la demande (Mermaid, KaTeX, PlantUML, etc.).
+**OntoWave** est une bibliothèque de navigation pour sites statiques et applications web. Elle transforme des fichiers Markdown en documentation interactive dans le navigateur, avec routing SPA basé sur le hash URL.
 
-> **Contrainte « zéro dépendance »** : s'applique au **noyau** `dist/ontowave.js` uniquement.
-> Les extensions vivent dans `dist/extensions/` et sont chargées dynamiquement — elles peuvent avoir des dépendances.
+> **État actuel (v1.x)** : bundle monolithique unique `dist/ontowave.min.js` (~4.7MB non-gzippé). Tout est bundlé : Markdown, Mermaid, KaTeX, Highlight, PlantUML.
+>
+> **Architecture cible (v2.0)** : noyau ≤ 200KB + extensions chargées à la demande. Décrit dans [docs/specs/architecture.fr.md](../docs/specs/architecture.fr.md). **NE PAS anticiper cette architecture avant les issues correspondantes.**
+>
+> **Contrainte « zéro dépendance »** : s'applique au **noyau** `dist/ontowave.js` uniquement (objectif v2.0).
 
 - Package npm : `ontowave`
 - Sites : https://ontowave.org et https://ontowave.com (identiques)
@@ -20,8 +23,9 @@
 
 ### Implémenté (dans `main`)
 
-- `bootstrapDom(cfg)` dans `src/main.ts` : la librairie crée tout le DOM (shell, menu, layout)
-- `docs/index.html` est quasi-vide : juste `<script src="/ontowave.min.js">` — c'est la référence
+- `bootstrapDom(cfg)` dans `src/main.ts` : la librairie crée tout le DOM (shell, menu, layout).
+  Guard `#app` : si l'élément préexiste → STOP TOTAL (aucun DOM, aucun style, aucun menu)
+- `docs/index.html` : `<noscript>` SEO + `window.ontoWaveConfig` + `<script src="/ontowave.min.js">` — c'est la référence
 - Routing SPA hash-based via `src/router.ts`
 - Fetch + cache de fichiers Markdown
 - Rendu Markdown, KaTeX, Mermaid, Highlight, PlantUML, SVG inline (**tout bundlé dans un seul fichier, ~4.7MB actuellement**)
@@ -213,35 +217,45 @@ Après que le tag `latest` npm est mis à jour, un smoke-test Playwright doit ê
 ## Multilingue
 
 - **Langue source : français** (`*.fr.md`) — c'est la version de référence à rédiger en premier
-- **Traduction anglaise obligatoire** (`*.en.md`) — chaque page française doit avoir son équivalent anglais pour les sites ontowave.org/com
-- Les fichiers de contenu utilisent le suffixe de langue : `index.fr.md`, `index.en.md`
-- La configuration de `roots` dans le config JSON permet de mapper des `base` URL vers des `root` de fichiers
+- **Traduction anglaise obligatoire** (`*.en.md`) — chaque page française doit avoir son équivalent anglais
+- Les fichiers utilisent le suffixe de langue : `index.fr.md`, `index.en.md`
+- **Multilinguisme = explicite** : sans déclaration `i18n` dans la config, OntoWave est unilingue et charge `*.md` sans suffixe
+- Deux patterns de structuration supportés : côte-à-côte (`index.fr.md` + `index.en.md` dans le même dossier) OU dossiers séparés (`/fr/index.md` + `/en/index.md`)
 - `normalizePath()` dans `src/core/logic.ts` est la référence pour la normalisation des chemins
 - Quand on crée ou modifie un fichier `.fr.md`, toujours créer ou mettre à jour le `.en.md` correspondant
+
+## Principes fondamentaux non-négociables
+
+> Ces règles gouvernent tout le code. Tout commit qui les viole doit être corrigé immédiatement.
+
+1. **Jamais de fetch externe sans directive explicite** : OntoWave ne requête jamais un fichier de configuration ou de contenu sans que l'intégrateur en ait déclaré l'intention. La config vient exclusivement de `window.ontoWaveConfig` ou `window.__ONTOWAVE_BUNDLE__`.
+
+2. **`window.ontoWaveConfig = {roots, i18n}` est l'API d'injection recommandée** : objet de config directement, converti en `__ONTOWAVE_BUNDLE__['/config.json']` par la lib. `__ONTOWAVE_BUNDLE__` reste l'API bas niveau pour injecter plusieurs fichiers à la fois.
+
+3. **La page HTML est quasi-vide** : `<noscript>` SEO + `window.ontoWaveConfig` + `<script src="...ontowave.min.js">`. Rien d'autre. Spec complète : [docs/specs/interface.fr.md](../docs/specs/interface.fr.md).
+
+4. **Guard `#app` = STOP total** : si `document.getElementById('app')` préexiste, `bootstrapDom()` ne crée rien (ni menu, ni styles, ni layout).
+
+5. **Hash routing = contrainte documentée** : v1.x prend possession exclusive de `window.location.hash`. Compatible uniquement avec les sites statiques où toutes les URLs se résolvent vers `index.html`. Le mode composant (v2.0, issue #77) résoudra cette contrainte.
 
 ## Principe fondateur — HTML minimal
 
 > **La page HTML est quasi-vide. La librairie crée tout le DOM.**
 
-La spécification complète est dans [docs/specs/interface.fr.md](../docs/specs/interface.fr.md).
+Spec complète dans [docs/specs/interface.fr.md](../docs/specs/interface.fr.md).
 
 ### `docs/index.html` — Invariants anti-dérive (non négociables)
 
-`docs/index.html` est la **référence utilisateur**. Elle ne doit contenir que : DOCTYPE + head (meta/title) + `<noscript>` SEO + `<script src="/ontowave.min.js">`.
+`docs/index.html` est la **référence utilisateur**. Elle ne doit contenir que : DOCTYPE + head + `<noscript>` SEO + `window.ontoWaveConfig` + `<script src="/ontowave.min.js">`.
 
 Tout `<style>`, `#site-header`, `#sidebar`, `#layout` ou `#toc` dans `docs/index.html` est une **dérive de conception** — à corriger immédiatement.
 
-### Menu flottant — Identité visuelle de référence
-
-- **Fond** : `rgba(255,255,255,0.95)` + `backdrop-filter: blur(10px)` + `border: 1px solid #e1e4e8`
-- **Icône** : `&#127754;` (🌊 emoji natif), cercle compact ≈ 66×66px
-- **Expansion** : horizontale (pill), révèle brand + options + boutons langue
-- **Drag & Drop** : obligatoire, session uniquement
-- **Pas de** header fixe, sidebar, TOC dans le DOM — navigation via le menu flottant uniquement
+**Exception légitime** : le bloc `<noscript>` pour le SEO. Ce n'est pas une dérive.
 
 ## À éviter
 
-- N'ajoute pas de dépendances npm dans `dependencies` — la lib doit rester zéro-dépendance
+- N'ajoute pas de `fetch()` pour lire une configuration ou un fichier externe sans que la page hôte l'ait déclaré explicitement via `window.ontoWaveConfig` ou `window.__ONTOWAVE_BUNDLE__`
+- N'ajoute pas de dépendances npm dans `dependencies` — la lib doit rester zéro-dépendance (objectif noyau v2.0)
 - N'utilise pas d'API navigateur dans `src/core/` (DOM, fetch, localStorage…)
 - N'introduis pas de code-splitting ou de chunks dynamiques dans le build de distribution
 - N'écris pas de tests `it.only` ou `test.only` sans retirer le `.only` avant commit

--- a/docs/index.html
+++ b/docs/index.html
@@ -309,6 +309,15 @@ MarkdownProcessor --&gt; PlantUMLPlugin : uses
   </div>
 </noscript>
 <!-- noscript:seo:end -->
+    <script>
+      window.ontoWaveConfig = {
+        roots: [
+          { base: 'fr', root: '/' },
+          { base: 'en', root: '/' }
+        ],
+        i18n: { default: 'fr', supported: ['fr', 'en'] }
+      };
+    </script>
     <script src="/ontowave.min.js"></script>
 </body>
 </html>

--- a/docs/specs/interface.en.md
+++ b/docs/specs/interface.en.md
@@ -1,9 +1,7 @@
 # Specifications — OntoWave Bootstrap Interface
 
-**Reference version**: `ontowave.js` March 2026 (pure JS class)  
-**Applies to**: `dist/ontowave.min.js` v1.x and above  
 **Language**: English (translation) — [Version française](interface.fr.md)  
-**Status**: Living document — all implementations must conform
+**Status**: Living document — all implementations must conform — versioned by git
 
 ---
 
@@ -22,18 +20,25 @@ A correct OntoWave page contains only:
   <title>My site</title>
 </head>
 <body>
-  <script src="https://unpkg.com/ontowave/dist/ontowave.min.js"></script>
+  <script>
+    window.ontoWaveConfig = { roots: [{ base: '/', root: '/' }] };
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/ontowave@latest/dist/ontowave.min.js"></script>
 </body>
 </html>
 ```
 
-The library automatically detects configuration, creates the interface and loads content. **The user defines nothing in HTML.**
+The library creates the entire interface. **The user defines no DOM in HTML.**
 
 ---
 
-## 2. Optional Inline Configuration
+## 2. Configuration Injection
 
-Configuration can be passed directly in the page, before the library `<script>`:
+OntoWave **never fetches an external configuration file**. Configuration must be injected by the host page. Two APIs are available:
+
+### Option A — `window.ontoWaveConfig` (recommended)
+
+The simplest API. Declare the configuration object directly in the page, before the library `<script>`:
 
 ```html
 <body>
@@ -46,25 +51,44 @@ Configuration can be passed directly in the page, before the library `<script>`:
       i18n: { default: 'en', supported: ['en', 'fr'] }
     };
   </script>
-  <script src="https://unpkg.com/ontowave/dist/ontowave.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ontowave@latest/dist/ontowave.min.js"></script>
 </body>
 ```
 
-**Configuration resolution priority** (descending order):
+The library reads `window.ontoWaveConfig` and automatically converts it to `window.__ONTOWAVE_BUNDLE__['/config.json']`.
 
-1. `window.ontoWaveConfig` (inline in the page)
-2. Config bundled in the library (embedded `config.json`)
-3. `config.json` fetched from the site root
+### Option B — `window.__ONTOWAVE_BUNDLE__` (low-level API)
+
+Advanced API for pages/tools that need to inject multiple files (config, nav, sitemap, search-index) in a single operation:
+
+```html
+<script>
+  window.__ONTOWAVE_BUNDLE__ = {
+    '/config.json': JSON.stringify({ roots: [...], i18n: {...} }),
+    '/nav.yml': '[]',
+    '/sitemap.json': '{"items":[]}',
+    '/search-index.json': '[]'
+  };
+</script>
+```
+
+### Behavior without configuration
+
+If neither API is defined, OntoWave starts in **minimal monolingual mode**:
+- Default config: `{ roots: [{ base: '/', root: '/' }] }`
+- Loads the home page: `#/index.md`
+- No network request to find a configuration
 
 ---
 
 ## 3. Automatic Bootstrap
 
-On load, the library applies this algorithm:
+On load, `bootstrapDom()` applies this algorithm:
 
 ```
-1. Read configuration (per §2 priority)
-2. If document.getElementById('app') exists → STOP (custom mode)
+1. Read configuration (§2 — injection only, never fetch)
+2. If document.getElementById('app') exists → COMPLETE STOP
+   (no DOM, no style, no menu — integration mode)
 3. Otherwise → create full DOM:
    a. Inject <style id="ow-bootstrap-styles"> with base CSS
    b. Create <div id="ow-content"><div id="app"></div></div>
@@ -72,7 +96,7 @@ On load, the library applies this algorithm:
    d. Initialize router and load default page
 ```
 
-**The `#app` guard is idempotent**: demo pages that define `<div id="app">` in their HTML are not affected by bootstrap.
+**The `#app` guard is a complete stop**: if `#app` pre-exists, nothing is created — no menu, no styles, no layout. This allows embedding OntoWave in an existing interface.
 
 ---
 
@@ -233,11 +257,16 @@ While the panel is open:
   <meta name="description" content="...">
 </head>
 <body>
-  <noscript><!-- Bilingual SEO content --></noscript>
+  <noscript><!-- Bilingual SEO content — legitimate exception --></noscript>
+  <script>
+    window.ontoWaveConfig = { roots: [...], i18n: {...} };
+  </script>
   <script src="/ontowave.min.js"></script>
 </body>
 </html>
 ```
+
+**Legitimate exception**: the `<noscript>` block for SEO (static bilingual content for crawlers). This is not a design drift.
 
 **Verifiable invariants (to test in CI)**:
 
@@ -245,11 +274,51 @@ While the panel is open:
 - `docs/index.html` does not contain `#sidebar`
 - `docs/index.html` does not contain `#layout`
 - `docs/index.html` does not contain a `<style>` block outside `<noscript>`
-- Line count excluding `<noscript>` is ≤ 15
+- Non-`<noscript>` content is ≤ 20 lines
 
 ---
 
-## 10. Non-Regression Contract
+## 10. Multilingualism
+
+**By default, OntoWave is monolingual**. Multilingualism is always **explicit** — declared in the configuration:
+
+```javascript
+window.ontoWaveConfig = {
+  roots: [
+    { base: 'fr', root: 'content/fr/' },
+    { base: 'en', root: 'content/en/' }
+  ],
+  i18n: { default: 'en', supported: ['en', 'fr'] }
+};
+```
+
+Without `i18n` declaration: monolingual — loads `*.md` files without language suffix.
+
+### Two supported file patterns
+
+**Pattern 1 — Side by side**: `index.fr.md` and `index.en.md` in the same folder  
+**Pattern 2 — Separate folders**: `/fr/index.md` and `/en/index.md`
+
+Both patterns are fully supported. Choose according to your content organization.
+
+---
+
+## 11. Demo Pages — Two Versions
+
+Each demo page in `docs/` must exist in **two copies**:
+
+| Version | `<script src>` | Use |
+|---------|----------------|-----|
+| `demo-xxx.html` | CDN `@latest` via jsdelivr | Published site, always up to date |
+| `demo-xxx.ci.html` | `/ontowave.min.js` (local) | Playwright CI, reproducible tests |
+
+This separation ensures:
+- The published site always shows the latest released version
+- CI tests run against the exact local build being validated
+
+---
+
+## 12. Non-Regression Contract
 
 Any commit modifying `src/main.ts` or `src/adapters/` must satisfy:
 

--- a/docs/specs/interface.fr.md
+++ b/docs/specs/interface.fr.md
@@ -1,7 +1,5 @@
 # Spécifications — Interface Bootstrap OntoWave
 
-**Version de référence** : `ontowave.js` mars 2026 (classe JS pure)  
-**Applicable à** : `dist/ontowave.min.js` v1.x et supérieur  
 **Langue** : Français (référence) — [English version](interface.en.md)  
 **Statut** : Document vivant — toute implémentation doit y être conforme
 
@@ -31,9 +29,13 @@ La librairie détecte automatiquement la configuration, crée l'interface et cha
 
 ---
 
-## 2. Configuration inline optionnelle
+## 2. Injection de la configuration
 
-Il est possible de passer une configuration directement dans la page, avant le `<script>` de la librairie :
+OntoWave **ne requête jamais de fichier de configuration externe**. La configuration doit être injectée par la page hôte avant le chargement de la librairie. Deux API sont disponibles.
+
+### Option A — `window.ontoWaveConfig` (recommandée)
+
+L'API la plus simple : déclarer l'objet de configuration directement dans la page.
 
 ```html
 <body>
@@ -46,15 +48,34 @@ Il est possible de passer une configuration directement dans la page, avant le `
       i18n: { default: 'fr', supported: ['fr', 'en'] }
     };
   </script>
-  <script src="https://unpkg.com/ontowave/dist/ontowave.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ontowave@latest/dist/ontowave.min.js"></script>
 </body>
 ```
 
-**Priorité de résolution de la configuration** (ordre décroissant) :
+La librairie lit `window.ontoWaveConfig` et le convertit automatiquement en entrée de `window.__ONTOWAVE_BUNDLE__['/config.json']`.
 
-1. `window.ontoWaveConfig` (inline dans la page)
-2. Config bundlée dans la librairie (`config.json` embarqué)
-3. `config.json` fetché à la racine du site
+### Option B — `window.__ONTOWAVE_BUNDLE__` (API bas niveau)
+
+Pour les pages qui doivent injecter plusieurs fichiers en une seule opération (config, nav, sitemap, search-index) — utilisé notamment par les pages de démo.
+
+```html
+<script>
+  window.__ONTOWAVE_BUNDLE__ = {
+    '/config.json': JSON.stringify({ roots: [...], i18n: {...} }),
+    '/nav.yml': '[]',
+    '/sitemap.json': '{"items":[]}',
+    '/search-index.json': '[]'
+  };
+</script>
+```
+
+### Comportement sans configuration
+
+Si aucune API n'est définie, OntoWave démarre en **mode unilingue minimal** :
+
+- Config par défaut : `{ roots: [{ base: '/', root: '/' }] }`
+- Charge la page d'accueil : `#/index.md`
+- Aucune requête réseau pour trouver une configuration
 
 ---
 
@@ -63,8 +84,9 @@ Il est possible de passer une configuration directement dans la page, avant le `
 Au chargement, la librairie applique l'algorithme suivant :
 
 ```
-1. Lire la configuration (selon priorité §2)
-2. Si document.getElementById('app') existe → STOP (mode custom)
+1. Lire la configuration (window.ontoWaveConfig ou window.__ONTOWAVE_BUNDLE__)
+2. Si document.getElementById('app') existe → STOP TOTAL (mode custom)
+   → Aucun DOM créé, aucun style injecté, aucun menu flottant
 3. Sinon → créer le DOM complet :
    a. Injecter <style id="ow-bootstrap-styles"> avec le CSS de base
    b. Créer <div id="ow-content"><div id="app"></div></div>
@@ -72,7 +94,7 @@ Au chargement, la librairie applique l'algorithme suivant :
    d. Initialiser le routeur et charger la page par défaut
 ```
 
-**Le guard `#app` est idempotent** : les pages de démo qui définissent `<div id="app">` dans leur HTML ne sont pas affectées par le bootstrap.
+**Le guard `#app` est exclusif** : toute page qui pré-définit `<div id="app">` prend le contrôle total du DOM. OntoWave ne crée rien.
 
 ---
 
@@ -221,7 +243,7 @@ Pendant que le panneau est ouvert :
 
 ## 9. Règle anti-dérive pour `docs/index.html`
 
-`docs/index.html` est la **référence utilisateur** du projet. Elle doit satisfaire toutes les contraintes de cette spec. Elle ne doit donc contenir que :
+`docs/index.html` est la **référence utilisateur** du projet. Elle doit satisfaire toutes les contraintes de cette spec. Elle ne doit contenir que :
 
 ```html
 <!DOCTYPE html>
@@ -233,11 +255,16 @@ Pendant que le panneau est ouvert :
   <meta name="description" content="...">
 </head>
 <body>
-  <noscript><!-- Contenu SEO bilingue --></noscript>
+  <noscript><!-- Contenu SEO bilingue (exception documentée) --></noscript>
+  <script>
+    window.ontoWaveConfig = { roots: [...], i18n: {...} };
+  </script>
   <script src="/ontowave.min.js"></script>
 </body>
 </html>
 ```
+
+**Exception noscript** : le bloc `<noscript>` contenant du contenu SEO bilingue est la seule exception autorisée au principe "HTML quasi-vide". Ce bloc est destiné aux moteurs de recherche et lecteurs sans JavaScript. Il ne constitue pas une dérive de conception.
 
 **Invariants vérifiables (à tester en CI)** :
 
@@ -245,11 +272,49 @@ Pendant que le panneau est ouvert :
 - `docs/index.html` ne contient pas `#sidebar`
 - `docs/index.html` ne contient pas `#layout`
 - `docs/index.html` ne contient pas de bloc `<style>` hors du `<noscript>`
-- Le nombre de lignes hors `<noscript>` est ≤ 15
+- Le nombre de lignes hors `<noscript>` est ≤ 20
 
 ---
 
-## 10. Contrat de non-régression
+## 10. Multilinguisme
+
+### Modes supportés
+
+| Mode | Config | Exemple URL |
+|------|--------|-------------|
+| **Unilingue** (défaut) | Sans `i18n` ni `roots` avec bases | `#/index.md`, `#/guide/intro.md` |
+| **Côte-à-côte** | Fichiers `.fr.md` et `.en.md` dans le même dossier | `#/fr/index` → charge `index.fr.md` |
+| **Dossiers séparés** | Un dossier par langue sous une base | `#/fr/index` → root `/content/fr/` |
+
+### Règle fondamentale
+
+Le multilinguisme est **toujours explicite** — il doit être déclaré dans la config. Sans déclaration `i18n`, OntoWave est unilingue et charge les fichiers `.md` (sans suffixe de langue).
+
+### Détection de la langue initiale
+
+1. Paramètre hash si déjà présent (navigation directe vers `#/fr/...`)
+2. `i18n.default` de la config
+3. `navigator.language` si la langue détectée est dans `i18n.supported`
+4. Première base déclarée dans `roots`
+
+---
+
+## 11. Pages de démo — Deux versions
+
+Les pages de démo dans `docs/demos/` existent en deux versions :
+
+| Version | URL / Fichier | But |
+|---------|---------------|-----|
+| **CDN** | `*.html` (référencé dans le site) | Démontre l'usage réel avec `@latest` |
+| **Locale** | `*.local.html` (ou equivalent CI) | Tests E2E Playwright — charge `/ontowave.min.js` local |
+
+Cette dualité garantit :
+- Que le site public démontre toujours l'usage CDN standard
+- Que la CI teste toujours le code en cours de développement (pas la version publiée)
+
+---
+
+## 12. Contrat de non-régression
 
 Tout commit modifiant `src/main.ts` ou `src/adapters/` doit satisfaire :
 

--- a/docs/specs/roadmap.en.md
+++ b/docs/specs/roadmap.en.md
@@ -1,11 +1,13 @@
 # OntoWave Roadmap
 
-> Version: 1.0 — April 12, 2026  
-> Status: **approved**
+> Status: **approved** — versioned by git
 
 ## Vision
 
-**OntoWave** is an independent navigation core (~100KB, zero dependencies) for static sites and web applications. Lightweight extensions are loaded on demand based on content: Markdown, diagrams, math formulas, and beyond.
+**OntoWave** is a navigation library for static sites and web applications. It transforms Markdown files into interactive documentation in the browser, with hash URL-based SPA routing.
+
+**Current state (v1.x)**: monolithic bundle (~4.7MB unzipped), everything is bundled.  
+**v2.0 target**: core ≤ 200KB (zero dependencies) + extensions loaded on demand.
 
 OntoWave integrates naturally into the Panini ecosystem (PaniniFS, PublicationEngine, Pensine-web) but does not depend on it and does not assume it. It can be used standalone by any project.
 
@@ -13,14 +15,13 @@ OntoWave integrates naturally into the Panini ecosystem (PaniniFS, PublicationEn
 
 | What OntoWave is | What it is not |
 |---|---|
-| Navigation core (SPA, routing, fetch) | Static site generator |
+| Navigation library (SPA, routing, fetch) | Static site generator |
 | Embeddable presentation layer | Application framework |
-| Lazy-load extension registry | CMS |
-| Zero-dependency library (core) | Monolithic bundle |
+| Zero-dependency library (core target v2.0) | CMS |
 
-## v1.1 — Reference Interface
+## v1.1 — Interface and Configuration API
 
-**Goal**: stabilize what the user sees and touches. Immutable visual foundation.
+**Goal**: stabilize what the user sees and touches + recommended configuration API. Immutable foundation for v2.0.
 
 **Completion criterion**: `npm run check` passes + `docs/index.html` respects the invariants of [specs/interface.en.md](interface.en.md).
 
@@ -28,6 +29,8 @@ OntoWave integrates naturally into the Panini ecosystem (PaniniFS, PublicationEn
 |---|---|---|
 | #76 | Floating menu — frosted glass, pill, drag & drop | Full spec in [interface.en.md §4-5](interface.en.md) |
 | #17 | Responsive and mobile-first interface | |
+| to create | Implement `window.ontoWaveConfig` as syntactic sugar | Ref: [interface.en.md §2](interface.en.md) — converts object to `__ONTOWAVE_BUNDLE__['/config.json']` |
+| to create | Demo pages in two versions (CDN @latest + local CI) | Ref: [interface.en.md §11](interface.en.md) |
 
 ## v2.0 — Universal Content Navigator
 

--- a/docs/specs/roadmap.fr.md
+++ b/docs/specs/roadmap.fr.md
@@ -1,11 +1,13 @@
 # Roadmap OntoWave
 
-> Version : 1.0 — 12 avril 2026  
-> Statut : **approuvée**
+> Statut : **approuvée** — version gérée par git
 
 ## Vision
 
-**OntoWave** est un noyau de navigation indépendant (~100KB, zéro dépendance) pour sites statiques et applications web. Des extensions légères sont chargées à la demande selon le contenu : Markdown, diagrammes, formules mathématiques, et au-delà.
+**OntoWave** est une bibliothèque de navigation pour sites statiques et applications web. Elle transforme des fichiers Markdown en documentation interactive dans le navigateur, avec routing SPA basé sur le hash URL.
+
+**État actuel (v1.x)** : bundle monolithique (~4.7MB non-gzippé), tout est bundlé.  
+**Objectif v2.0** : noyau ≤ 200KB (zéro dépendance) + extensions chargées à la demande.
 
 OntoWave s'intègre naturellement dans l'écosystème Panini (PaniniFS, PublicationEngine, Pensine-web) mais n'en dépend pas et ne le suppose pas. Il est utilisable seul par n'importe quel projet.
 
@@ -13,14 +15,13 @@ OntoWave s'intègre naturellement dans l'écosystème Panini (PaniniFS, Publicat
 
 | Ce qu'est OntoWave | Ce qu'il n'est pas |
 |---|---|
-| Noyau de navigation (SPA, routing, fetch) | Générateur de site statique |
+| Bibliothèque de navigation (SPA, routing, fetch) | Générateur de site statique |
 | Couche de présentation embarquable | Framework applicatif |
-| Registre d'extensions lazy-load | CMS |
-| Bibliothèque zéro dépendance (noyau) | Bundle monolithique |
+| Bibliothèque zéro dépendance (objectif noyau v2.0) | CMS |
 
-## Palier v1.1 — Interface de référence
+## Palier v1.1 — Interface et API de configuration
 
-**Objectif** : stabiliser ce que l'utilisateur voit et touche. Fondation visuelle immuable.
+**Objectif** : stabiliser ce que l'utilisateur voit et touche + API de configuration recommandée. Fondation immuable pour v2.0.
 
 **Critère de clôture** : `npm run check` passe + `docs/index.html` respecte les invariants de [specs/interface.fr.md](interface.fr.md).
 
@@ -28,6 +29,8 @@ OntoWave s'intègre naturellement dans l'écosystème Panini (PaniniFS, Publicat
 |---|---|---|
 | #76 | Menu flottant — verre givré, pill, drag & drop | Spec complète dans [interface.fr.md §4-5](interface.fr.md) |
 | #17 | Interface responsive et mobile-first | |
+| à créer | Implémenter `window.ontoWaveConfig` comme sucre syntaxique | Ref : [interface.fr.md §2](interface.fr.md) — convertit l'objet en `__ONTOWAVE_BUNDLE__['/config.json']` |
+| à créer | Pages de démo en deux versions (CDN @latest + local CI) | Ref : [interface.fr.md §11](interface.fr.md) |
 
 ## Palier v2.0 — Navigateur de contenu universel
 


### PR DESCRIPTION
## Contexte

Suite à la revue interactive complète de toutes les specs et du code (session du 15 avril 2026). Ces commits mettent à jour les specs et la page de référence `docs/index.html` pour refléter les décisions arrêtées.

## Changements

### `docs/index.html`
- Injection `window.ontoWaveConfig` avant `<script src="/ontowave.min.js">`
- La page est maintenant conforme à la spec §9 (HTML minimal avec config injectée)

### `.github/copilot-instructions.md`
- Taille réelle ~4.7MB documentée
- Section «Principes fondamentaux non-négociables» (P1-P5)
- Règle P1 no-fetch ajoutée dans «À éviter»
- Multilingue : unilingue par défaut, deux patterns documentés
- Section menu flottant → pointeur vers `docs/specs/interface.fr.md §4`

### `docs/specs/interface.fr.md` + `interface.en.md`
- §2 réécrit : deux APIs (`window.ontoWaveConfig` + `__ONTOWAVE_BUNDLE__`) sans fetch
- §3 : guard `#app` = STOP TOTAL documenté
- §9 : injection config + exception noscript documentée
- §10 NOUVEAU : Multilinguisme
- §11 NOUVEAU : Deux versions de démos (CDN + local CI)
- §12 : Contrat de non-régression (renommé)

### `docs/specs/roadmap.fr.md` + `roadmap.en.md`
- Versions manuelles supprimées (git = source of truth)
- Vision corrigée : état actuel (~4.7MB) vs objectif v2.0
- v1.1 : deux nouvelles issues identifiées (issues #97 et #98)

## Issues créées lors de cette revue
- #97 : `window.ontoWaveConfig` sugar implementation
- #98 : Démos deux versions
- #99 : Archiver docs fossiles

## Critères d'acceptation
- `npm test` passe
- `npm run build:package` passe
- `docs/index.html` conforme : `window.ontoWaveConfig` présent avant le script